### PR TITLE
from_epsg and to_prj methods have been added to Sridentify class.

### DIFF
--- a/sridentify/__init__.py
+++ b/sridentify/__init__.py
@@ -168,3 +168,27 @@ class Sridentify(object):
             self.conn.rollback()
             logger.warning("%s is already in the database" % self.prj)
         self.conn.commit()
+
+    def from_epsg(self, epsg_code):
+        """
+        Loads self.prj by epsg_code.
+        If prjtext not found returns False.
+        """
+        self.epsg_code = epsg_code
+        assert isinstance(self.epsg_code, int)
+        cur = self.conn.cursor()
+        cur.execute("SELECT prjtext FROM prj_epsg WHERE epsg_code = ?", (self.epsg_code,))
+        result = cur.fetchone()
+        if result is not None:
+            self.prj = result[0]
+            return True
+
+        return False
+
+
+    def to_prj(self, filename):
+        """
+        Saves prj WKT to given file.
+        """
+        with open(filename, "w") as fp:
+            fp.write(self.prj)

--- a/tests/test_api_mode.py
+++ b/tests/test_api_mode.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import tempfile
 
 from sridentify import Sridentify
 
@@ -12,6 +13,7 @@ except NameError:
 
 
 class SridentifyAPIModeTest(unittest.TestCase):
+    WKT_3435 = """PROJCS["NAD_1983_StatePlane_Illinois_East_FIPS_1201_Feet",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Transverse_Mercator"],PARAMETER["False_Easting",984250.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-88.33333333333333],PARAMETER["Scale_Factor",0.999975],PARAMETER["Latitude_Of_Origin",36.66666666666666],UNIT["Foot_US",0.3048006096012192]]"""
 
     def setUp(self):
         self.this_dir = os.path.abspath(os.path.dirname(__file__))
@@ -29,10 +31,27 @@ class SridentifyAPIModeTest(unittest.TestCase):
         self.assertEqual(self.ident.get_epsg(), 3435)
 
     def test_get_epsg_from_text_string(self):
-        self.ident.prj = """PROJCS["NAD_1983_StatePlane_Illinois_East_FIPS_1201_Feet",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Transverse_Mercator"],PARAMETER["False_Easting",984250.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-88.33333333333333],PARAMETER["Scale_Factor",0.999975],PARAMETER["Latitude_Of_Origin",36.66666666666666],UNIT["Foot_US",0.3048006096012192]]"""
+        self.ident.prj = SridentifyAPIModeTest.WKT_3435
         self.assertEqual(self.ident.get_epsg(), 3435)
 
+    def test_from_epsg_existing_epsg(self):
+        self.assertEqual(self.ident.from_epsg(3435), True)
+        self.assertEqual(self.ident.prj, SridentifyAPIModeTest.WKT_3435)
 
+    def test_from_epsg_unexisting_epsg(self):
+        self.assertEqual(self.ident.from_epsg(-1), False)
+
+    def test_to_prj(self):
+        self.ident.from_epsg(3435)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = os.path.join(temp_dir, 'file.prj')
+            self.ident.to_prj(filename)
+            with open(filename, 'r') as fp:
+                contents = fp.read()
+                self.assertEqual(
+                    contents,
+                    SridentifyAPIModeTest.WKT_3435,
+                )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello.
I would like to suggest new feature for sridentify library.
There are two methods from_epsg and to_prj which allows to create .prj file from epsg code.

Example of usage:
ident = sridentify.Sridentify()  
ident.from_epsg(4326)  
ident.to_prj('file.prj')  


